### PR TITLE
Fix/issue68-pyproject-toml

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -70,7 +70,7 @@ Ready to contribute? Here's how to set up `timelink-py` for local development.
 
     $ mkvirtualenv timelink
     $ cd timelink/
-    $ python setup.py develop
+    $ pip install -e .
 
 4. Create a branch for local development::
 
@@ -82,7 +82,7 @@ Ready to contribute? Here's how to set up `timelink-py` for local development.
    tests, including testing other Python versions with tox::
 
     $ flake8 timelink tests
-    $ python setup.py test or pytest
+    $ pytest
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.
@@ -278,8 +278,8 @@ If GitHub Actions fails to deploy to PyPI:
 
 * Try "make release" locally.
 
-  * Note that errors in package description in setup.py can prevent deployment to PyPI.
-  * This happens mainly with markup problems in HISTORY.rst.
+  * Note that errors in package description in pyproject.toml or README.rst can prevent deployment to PyPI.
+  * This happens mainly with markup problems in HISTORY.rst or invalid metadata.
   * See https://github.com/pypi/warehouse/issues/5890
 
 "make release" will do `twine check dist/*` to check for errors.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -44,7 +44,7 @@ Once you have a copy of the source, you can install it with:
 
 .. code-block:: console
 
-    $ python setup.py install
+    $ pip install .
 
 
 .. _Github repo: https://github.com/time-link/timelink-py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,19 +119,3 @@ max-line-length = 120
 select = ["C", "E", "F", "W", "B", "B950"]
 extend-ignore = ["E203", "E501", "W503", "W504"]
 
-# Bump2version configuration
-[tool.bumpversion]
-current_version = "1.1.27"
-commit = true
-tag = true
-
-[[tool.bumpversion.files]]
-filename = "timelink/__init__.py"
-search = "__version__ = '{current_version}'"
-replace = "__version__ = '{new_version}'"
-
-[[tool.bumpversion.files]]
-filename = "pyproject.toml"
-search = "version = \"{current_version}\""
-replace = "version = \"{new_version}\""
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Sociology :: History",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,137 @@
-# We use this just for the black code formater to prevent it from
-#  replacing single quotes with double quotes in timelink/__init__.py
-#  because it breaks bump2version
-#     see https://github.com/oceanprotocol/ocean.py/issues/194
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "timelink"
+version = "1.1.27"
+authors = [
+    {name = "Joaquim Ramos de Carvalho", email = "joaquimcarvalho@mpu.edu.mo"},
+]
+description = "Timelink is an information system for person related information collected from historical sources."
+readme = "README.rst"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+keywords = ["timelink", "history", "prosopography", "kleio", "historical-data"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Sociology :: History",
+]
+dependencies = [
+    "typer>=0.9.0",
+    "fastapi",
+    "matplotlib",
+    "sqlalchemy",
+    "sqlalchemy-utils",
+    "alembic",
+    "pydantic",
+    "pydantic-settings",
+    "python-dotenv",
+    "python-box",
+    "python-multipart",
+    "psycopg2-binary",
+    "py-markdown-table",
+    "python-jose[cryptography]",
+    "pandas",
+    "docker",
+    "jsonrpcclient",
+    "ipython",
+    "uvicorn",
+    "requests",
+]
+
+[project.optional-dependencies]
+dev = [
+    "alabaster==0.7.12",
+    "argh~=0.28.1",
+    "black>=24.3.0",
+    "build",
+    "bump2version==1.0.1",
+    "coverage==5.5",
+    "docutils>=0.19.0",
+    "flake8-bugbear==24.4.26",
+    "flake8==7.1.1",
+    "nbsphinx",
+    "nbval>=0.10.0",
+    "pipdeptree",
+    "pytest>=8",
+    "pytest-profiling",
+    "snakeviz",
+    "sphinx_rtd_theme>=1.2.0",
+    "sphinx-rtd-theme",
+    "tox",
+    "twine==4.0.2",
+    "watchdog==2.1.3",
+]
+test = [
+    "pytest>=8",
+    "coverage==5.5",
+    "nbval>=0.10.0",
+]
+
+[project.urls]
+Documentation = "https://timelink-py.readthedocs.io/"
+"Source Code" = "https://github.com/time-link/timelink-py"
+"Bug Tracker" = "https://github.com/time-link/timelink-py/issues"
+Homepage = "https://github.com/time-link/timelink-py"
+
+[project.scripts]
+timelink = "timelink.cli:app"
+tmlk = "timelink.cli:app"
+
+[tool.setuptools]
+zip-safe = false
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["timelink", "timelink.*"]
+
+[tool.setuptools.package-data]
+timelink = [
+    "migrations/versions/*.py",
+    "alembic.ini",
+    "app/static/*",
+    "app/templates/**/*",
+]
+
+# Black code formatter configuration
+# We exclude __init__.py to prevent it from replacing single quotes
+# with double quotes, which breaks bump2version
+# See https://github.com/oceanprotocol/ocean.py/issues/194
 [tool.black]
 line-length = 120
 exclude = '__init__.py'
 extend-immutable-calls = 'Depends, fastapi.Depends, fastapi.params.Depends'
 
-[tool.poetry]
-name = "timelink"
-# ... other poetry configuration ...
+# Flake8 linter configuration
+[tool.flake8]
+exclude = ["docs"]
+max-line-length = 120
+select = ["C", "E", "F", "W", "B", "B950"]
+extend-ignore = ["E203", "E501", "W503", "W504"]
 
-[tool.poetry.include]
-"timelink/migrations/versions/*" = {format = "sdist", extension = "py"}
+# Bump2version configuration
+[tool.bumpversion]
+current_version = "1.1.27"
+commit = true
+tag = true
+
+[[tool.bumpversion.files]]
+filename = "timelink/__init__.py"
+search = "__version__ = '{current_version}'"
+replace = "__version__ = '{new_version}'"
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = "version = \"{current_version}\""
+replace = "version = \"{new_version}\""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ dev = [
     "pytest-profiling",
     "snakeviz",
     "sphinx_rtd_theme>=1.2.0",
-    "sphinx-rtd-theme",
     "tox",
     "twine==4.0.2",
     "watchdog==2.1.3",

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,9 @@ current_version = 1.1.27
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
+[bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
 
 [bumpversion:file:timelink/__init__.py]
 search = __version__ = '{current_version}'


### PR DESCRIPTION
- Replace 'python setup.py develop' with 'pip install -e .' in CONTRIBUTING.rst
- Replace 'python setup.py test' with 'pytest' in CONTRIBUTING.rst
- Update deployment notes to mention pyproject.toml instead of setup.py
- Replace 'python setup.py install' with 'pip install .' in docs/installation.rst

These changes reflect modern Python packaging best practices and align
with the migration from setup.py to pyproject.toml.

Refs: #68