### PR TITLE
Fix cross-database contamination from stale PomSomMapper state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ env:
   # Environment variables
   TRAVIS: true  # For compatibility with existing test configs
   GITHUB_ACTIONS: true  # For compatibility with existing test configs
+  # Kleio server image tag. Pinned to a promoted build for reproducible CI;
+  # keep in sync with DEFAULT_KLEIO_VERSION in timelink/kleio/kleio_server.py
+  # and STACK.md. See RELEASE_CHECKLIST.md for the coordinated-release flow.
+  KLEIO_VERSION: "12.9.588"
 
 jobs:
   lint:
@@ -78,7 +82,7 @@ jobs:
     - name: Pull Docker images
       run: |
         docker pull postgres:latest
-        docker pull timelinkserver/kleio-server:latest
+        docker pull timelinkserver/kleio-server:${KLEIO_VERSION}
 
     - name: Stop default PostgreSQL
       run: |

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,230 @@
+# Timelink release checklist
+
+A lightweight, single-developer workflow for releasing changes across the
+three Timelink repositories in sync:
+
+| Repo            | Role                                          | Versioning                  |
+|-----------------|-----------------------------------------------|-----------------------------|
+| `timelink-kleio`| SWI-Prolog server; parses `.cli` → emits XML  | `major.minor.build` (files) |
+| `timelink-py`   | Consumes XML; Python API (this repo)          | `X.Y.Z` (bump2version)      |
+| `timelink-docs` | User-facing docs (MkDocs Material)            | unversioned (git ref)       |
+
+The **only hard coupling** is `kleio → XML → timelink-py`. Everything else
+is soft. The kleio image tag is pinned (not `:latest`); see STACK.md for the
+current verified-good combination.
+
+---
+
+## 1. Classify the change
+
+Every change falls into one of five types. The type dictates **which repos
+move and in what order**.
+
+| Type | What changes                                                      | kleio | py | docs | Coordination |
+|------|-------------------------------------------------------------------|:-----:|:--:|:----:|--------------|
+| **A**| Notation grammar (`dataSyntax.pl`, `struSyntax.pl`, `gacto2.str`)| ① | ② if importer/`sax_handler.py` affected | ③ notation ref + tutorial | **coordinated** |
+| **B**| XML output (`kleioExport.xsd`, `gactoxml.pl`) — *the contract*    | ① | ② **always** | ③ schema/mapping ref | **coordinated** |
+| **C**| Python API/behavior                                               | — | ① | ② if user-visible | single-repo |
+| **D**| Docs-only (clarify, typo, new example)                            | — | — | ① | single-repo |
+| **E**| Infra/CI/release mechanics                                        | ① | ① | ① | repo-local |
+
+For types A/B the work is **one logical change realized as N linked
+branches**, named with a shared token so the link is visible:
+
+```
+feat/<id>-kleio   e.g. feat/person-rel-xml-kleio
+feat/<id>-py            feat/person-rel-xml-py
+feat/<id>-docs          feat/person-rel-xml-docs
+```
+
+For C/D/E it's a single branch on one repo.
+
+### Tracking
+
+Open **one checklist issue on `timelink-py`** (the coordination home), label
+it per affected repo (`kleio` / `timelink-py` / `timelink-docs`) plus
+`change-type-A/B/C/D/E`. Close it only when every box below is ticked. No
+GitHub Projects boards, no per-repo issue duplication — for one person that
+is overhead with no payoff.
+
+---
+
+## 2. Single-repo release (types C / D / E)
+
+The normal flow for a change that touches only one repo.
+
+### timelink-py
+
+1. Branch off `origin/main` (worktree: `git worktree add <dir> -b feature/<id> origin/main`).
+2. Make the change.
+3. `pytest --rootdir=tests` (needs Docker + Postgres + kleio; see CI for the env).
+4. Add an entry to `HISTORY.rst` under a new version heading.
+5. `bumpversion patch|minor|major` — auto-bumps `setup.cfg` `current_version`
+   **and** `timelink/__init__.py` `__version__`, commits, and tags `vX.Y.Z`.
+6. `git push origin main --tags` (or merge via PR).
+7. The `v*` tag triggers the `deploy` job in `.github/workflows/ci.yml`
+   (trusted publishing to PyPI).
+
+> **Known drift risk:** the legacy `setup.py` also declares a `version=`.
+> `bumpversion` is **not** configured to update it (see `setup.cfg`
+> `[bumpversion:file:...]`). Ignore `setup.py`'s version; `pyproject.toml` /
+> `__init__.py` are authoritative.
+
+### timelink-docs
+
+1. Branch off `main`.
+2. Edit markdown (every file needs an `#` H1; lowercase + underscores in
+   filenames — see the repo's `README.md` "Style guidelines").
+3. Preview locally with `mkdocs serve`.
+4. Merge to `main`. `.github/workflows/ci.yml` runs `mkdocs gh-deploy --force`
+   → publishes to GitHub Pages.
+
+### timelink-kleio
+
+1. Branch off `main` in the `timelink-kleio` clone.
+2. Edit Prolog source / structure files.
+3. `make build-local` — bumps `kleio.build.number`, runs `prepare`
+   (substitutes `@@VERSION@@/@@BUILD@@/@@DATE@@`), builds the local image.
+4. `make test-semantics` (and `make test-api` if REST-facing).
+5. **This repo has no CI and no changelog yet** — see §5 caveats and the
+   follow-on list in STACK.md.
+
+---
+
+## 3. Coordinated release (types A / B)
+
+Strict propagation order, because each step feeds the next:
+
+```
+kleio ──tag/image──▶ py (pin + test against new image) ──tag──▶ docs (cite both) ──merge──▶ STACK.md
+```
+
+### Step 1 — kleio
+
+1. Finish the `feat/<id>-kleio` branch; run `make test-semantics`.
+2. `make inc-build` → bumps `kleio.build.number` (e.g. 588 → 589).
+   - Use `make inc-minor` / `inc-major` only for a real version bump; see
+     caveats in §5 (they do **not** reset the build number).
+3. `make build-multi` → builds multi-arch and `docker buildx build --push`s
+   `timelinkserver/kleio-server:<ver>` to Docker Hub.
+4. `make tag-multi-stable` → re-tags as `:12.9` and `:12`, and creates the
+   git tag `<ver>` (e.g. `12.9.589`).
+5. **Push the git tag** — `make tag-multi-stable` does **not** run
+   `git push --tags` (caveat §5). Do it yourself.
+6. Add a `CHANGELOG.md` entry (the kleio repo has no changelog yet — see
+   STACK.md follow-on list; until it exists, record the change in the
+   tracking issue).
+7. Verify on Docker Hub that `<ver>`, `:12.9`, `:latest` all point to the
+   same new digest:
+   ```bash
+   for t in 12.9.589 12.9 latest; do
+     docker manifest inspect timelinkserver/kleio-server:$t \
+       | python3 -c "import sys,json;print(json.load(sys.stdin)['manifests'][0]['digest'])"
+   done
+   ```
+
+### Step 2 — timelink-py
+
+1. Finish the `feat/<id>-py` branch.
+2. Update the kleio pin in **all three** sync sites to the new build:
+   - `timelink/kleio/kleio_server.py` → `DEFAULT_KLEIO_VERSION`
+   - `tests/__init__.py` → `use_kleio_version`
+   - `.github/workflows/ci.yml` → `env.KLEIO_VERSION`
+3. `pytest --rootdir=tests` against the new image.
+4. Add a `HISTORY.rst` entry.
+5. `bumpversion patch|minor|major` → tags `vX.Y.Z`.
+6. `git push origin main --tags` → PyPI publish.
+
+### Step 3 — timelink-docs
+
+1. Finish the `feat/<id>-docs` branch.
+2. Add a version note ("Requires kleio ≥12.9.589, timelink-py ≥1.1.34").
+3. Merge to `main` → auto-`gh-deploy`.
+
+### Step 4 — STACK.md (LAST)
+
+1. Update the three rows in STACK.md (kleio build, py version, docs ref/date).
+2. Update the "Verified against" line.
+3. Commit to `timelink-py`.
+4. Optionally create a GitHub Release on `timelink-py` summarizing the three
+   changelogs.
+5. Run `./scripts/check-stack.sh` to confirm local reality matches.
+6. Close the tracking issue.
+
+---
+
+## 4. Defending the contract boundary (`kleio → XML → py`)
+
+The XML output is the only hard coupling. Defend it explicitly:
+
+- **Schema is the contract:** `timelink-kleio/src/kleioExport.xsd` + the XML
+  emitted by `src/gactoxml.pl`. Any type-B change edits these **first**.
+- **Round-trip test (follow-on):** a frozen representative `.cli` →
+  expected-XML pair under `tests/xml_data/`. On every kleio bump, re-export
+  that `.cli` with the new image and diff against expected. A diff fails the
+  py build before it reaches users. *(Not yet implemented — see STACK.md
+  follow-on list.)*
+- **Version handshake (follow-on):** kleio exposes its version via
+  `clio_version_version/1` predicates but has **no REST/JSON-RPC endpoint**
+  to return it. A future enhancement: add a `version` JSON-RPC method so
+  `timelink-py` can log the running kleio version on connect and warn if it
+  differs from `DEFAULT_KLEIO_VERSION`.
+
+---
+
+## 5. kleio release caveats (recorded so you don't re-hit them)
+
+These are sharp edges in the current `timelink-kleio` Makefile/release flow.
+Read before the first coordinated release.
+
+- **`tag-multi-stable` does not push tags.** It runs `git tag ${patch}` but
+  not `git push --tags`. You must push manually.
+- **Build number is never reset on minor/major bumps.** `inc-minor` and
+  `inc-major` bump their own number but leave `kleio.build.number` climbing
+  monotonically. (So `12.10` would start at whatever build `12.9` reached.)
+- **`inc-major` resets the minor (patch) number to 0** but `inc-minor` does
+  not reset build (consistent with the above, but worth knowing).
+- **No CI exists in `timelink-kleio`.** There is no `.github/` directory at
+  all. All builds and image releases are manual via `make`.
+- **`make prepare` path mismatch.** The `prepare` target `sed`s into
+  `.build/src/sources-structure.yaml`, but `cp -r ./src .build` places the
+  file at `.build/src/stru/sources-structure.yaml`. The substitution may
+  silently miss. Verify the built image reports the right version via its
+  `VERSION`/`BUILD` labels after `build-multi`.
+- **`get_server()` still defaults to `"latest"`.**
+  `KleioServer.get_server(kleio_version="latest")` is a *lookup-by-version*
+  helper, not a provisioning default; changing its behavior is a separate
+  decision and was intentionally left alone in the pin change. Revisit if it
+  causes confusion.
+- **No machine-readable version endpoint** — see §4 "Version handshake".
+
+---
+
+## 6. Security note
+
+`timelink-docs/.kleio.json` is tracked in git and historically contained a
+live `kleio_admin_token`. Remediation (deferred to the docs phase, per the
+user's "rotate + untrack forward" decision):
+
+1. Add `.kleio.json` to `timelink-docs/.gitignore`.
+2. `git rm --cached .kleio.json`.
+3. **Rotate** the live `kleio_admin_token` on the Kleio server side.
+
+Git history retains the old (now-dead) token. Scrubbing history
+(`git filter-repo` + force-push) was considered and rejected as destructive
+for a solo project; once rotated, the leaked token is harmless.
+
+---
+
+## 7. Day-to-day loop, condensed
+
+```
+1. Classify the change (A/B/C/D/E)            → §1 table
+2. Open one checklist issue on timelink-py,
+   label per affected repo                     → §1
+3. Create linked branches feat/<id>-{kleio,py,docs} as needed
+4. Work in propagation order; for type B, XML/schema first
+5. Per-repo: test → changelog → tag (kleio image, py tag, docs merge)
+6. Update STACK.md last; run scripts/check-stack.sh
+7. Close the issue; note in docs changelog
+```

--- a/STACK.md
+++ b/STACK.md
@@ -1,0 +1,59 @@
+# Timelink stack — compatibility manifest
+
+This file records a **known-good combination** of the three Timelink
+repositories. It is the single source of truth for "what works together"
+and replaces the scattered version references that used to drift
+(`:latest` docker pulls, stale `0.2.8` mentions, malformed `pip -U`).
+
+The three repositories are versioned **independently**; this file records a
+**verified set**. Each consuming project (e.g. `dehergne`) is encouraged to
+pin the same combination in its own `.kleio.json` / requirements.
+
+## Current set
+
+Released: 2026-07-17
+
+| Component      | Version   | Where                                                       |
+|----------------|-----------|-------------------------------------------------------------|
+| kleio-server   | 12.9.588  | docker `timelinkserver/kleio-server:12.9.588` (also `:12.9`, `:latest` — all the same digest as of this date) |
+| timelink-py    | 1.1.33    | PyPI `timelink` ; git `time-link/timelink-py@main`          |
+| timelink-docs  | _pending_ | git `time-link/timelink-docs`; to be filled by the docs phase |
+
+### Notes on the kleio build number
+
+- `12.9.588` is the latest build **promoted** to Docker Hub. The `:12.9`,
+  `:12`, `:latest` **and** `:12.9.588` tags all resolve to the same image
+  digest (`sha256:f7dbc284…`, verified 2026-07-17).
+- The `timelink-kleio` source tree may be ahead of this (local dev builds
+  such as `12.9.591`/`12.9.592` are **not** on Docker Hub until promoted via
+  `make build-multi` + `make tag-multi-stable`). STACK.md always records the
+  promoted value, not the dev value.
+
+## Verified against
+
+- timelink-py test suite: green against kleio `12.9.588` (Python 3.10–3.13).
+- Consuming project `dehergne` imports cleanly with kleio `12.9` / build 588
+  (see `dehergne/.kleio.json`).
+
+## Where the pin lives
+
+The kleio pin is expressed in **three places** that must stay in sync — all
+use the same env-var name `KLEIO_VERSION`:
+
+| Site                                             | Purpose                                  |
+|--------------------------------------------------|------------------------------------------|
+| `timelink/kleio/kleio_server.py` `DEFAULT_KLEIO_VERSION` | runtime default, overridable by `$KLEIO_VERSION` |
+| `tests/__init__.py` `use_kleio_version`          | test fixture                             |
+| `.github/workflows/ci.yml` `env.KLEIO_VERSION`   | CI image pull                            |
+
+`scripts/check-stack.sh` verifies the local reality matches this file.
+
+## Update rule
+
+**This file is updated LAST in every coordinated release** (kleio change of
+type A or B — see RELEASE_CHECKLIST.md). Only after kleio has been promoted,
+timelink-py has been tested against the new image and released, and docs
+have been updated, do you edit the three rows above and commit.
+
+For single-repo releases (timelink-py-only or docs-only), only the affected
+row moves.

--- a/scripts/check-stack.sh
+++ b/scripts/check-stack.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# check-stack.sh — verify the local Timelink stack matches STACK.md.
+#
+# Reads the pinned versions from STACK.md and checks local reality:
+#   - installed timelink-py version
+#   - $KLEIO_VERSION env override (warns if it differs from the pin)
+#   - kleio-server docker image present locally / on the registry
+#
+# Run before any release and after any `git pull`. Non-zero exit on mismatch.
+#
+# Usage:
+#   ./scripts/check-stack.sh            # from repo root
+#   ./scripts/check-stack.sh --quiet    # only print on mismatch
+#
+# No dependencies beyond git, python3, and (optionally) docker.
+
+set -u
+
+QUIET=0
+[ "${1:-}" = "--quiet" ] && QUIET=1
+
+# Locate STACK.md: this script may be run from repo root or from scripts/.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STACK_FILE="$REPO_ROOT/STACK.md"
+
+note() { [ "$QUIET" -eq 0 ] && echo "$@" || true; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+if [ ! -f "$STACK_FILE" ]; then
+  fail "STACK.md not found at $STACK_FILE"
+fi
+
+# --- read pinned values from STACK.md ----------------------------------------
+# Parse the markdown table rows. The version is in the 2nd column (between the
+# 2nd and 3rd "|"), so awk on "|" gives it as field 3 (field 1 is empty before
+# the leading "|"). We then trim whitespace and keep only the leading version
+# token, so any trailing annotation in the cell is ignored.
+extract_version() {
+  # $1 = component name (kleio-server | timelink-py)
+  awk -F'|' -v name="$1" '
+    $2 ~ "^[[:space:]]*" name "[[:space:]]*$" {
+      v = $3; sub(/^[[:space:]]+/, "", v); sub(/[[:space:]].*$/, "", v); print v; exit
+    }
+  ' "$STACK_FILE"
+}
+PINNED_KLEIO=$(extract_version "kleio-server")
+PINNED_PY=$(extract_version "timelink-py")
+
+[ -z "$PINNED_KLEIO" ] && fail "could not parse kleio-server version from STACK.md"
+[ -z "$PINNED_PY" ]    && fail "could not parse timelink-py version from STACK.md"
+
+note "STACK.md pin:  kleio-server=$PINNED_KLEIO  timelink-py=$PINNED_PY"
+echo
+
+# --- check 1: installed timelink-py version ----------------------------------
+note "## timelink-py"
+# Try the current python3; fall back to a sibling worktree's venv if present
+# (this repo uses a git-worktree layout where only `main/` may have a .venv).
+PY_FOR_CHECK="python3"
+if ! python3 -c "import timelink" >/dev/null 2>&1; then
+  for cand in "$REPO_ROOT/../main/.venv/bin/python" "$REPO_ROOT/.venv/bin/python"; do
+    if [ -x "$cand" ] && "$cand" -c "import timelink" >/dev/null 2>&1; then
+      PY_FOR_CHECK="$cand"; break
+    fi
+  done
+fi
+INSTALLED_PY=$("$PY_FOR_CHECK" -c "import timelink; print(timelink.__version__)" 2>/dev/null || true)
+if [ -z "$INSTALLED_PY" ]; then
+  echo "WARN: timelink-py not importable in any available python (skipped)"
+else
+  note "   installed: $INSTALLED_PY  (via $PY_FOR_CHECK)"
+  if [ "$INSTALLED_PY" = "$PINNED_PY" ]; then
+    note "   OK"
+  else
+    echo "WARN: installed timelink-py ($INSTALLED_PY) != STACK.md ($PINNED_PY)"
+    echo "      (expected if you are mid-release; update STACK.md last)"
+  fi
+fi
+echo
+
+# --- check 2: KLEIO_VERSION env override -------------------------------------
+note "## KLEIO_VERSION env"
+ENV_KLEIO="${KLEIO_VERSION:-}"
+if [ -z "$ENV_KLEIO" ]; then
+  note "   (not set — runtime/CI will use DEFAULT_KLEIO_VERSION=$PINNED_KLEIO)"
+else
+  note "   set to: $ENV_KLEIO"
+  if [ "$ENV_KLEIO" = "$PINNED_KLEIO" ]; then
+    note "   OK"
+  else
+    echo "WARN: \$KLEIO_VERSION ($ENV_KLEIO) != STACK.md ($PINNED_KLEIO)"
+    echo "      (intentional when testing a pre-release build)"
+  fi
+fi
+echo
+
+# --- check 3: docker image ---------------------------------------------------
+note "## kleio-server docker image: timelinkserver/kleio-server:$PINNED_KLEIO"
+IMAGE="timelinkserver/kleio-server:$PINNED_KLEIO"
+if ! command -v docker >/dev/null 2>&1; then
+  echo "WARN: docker not available (skipped image check)"
+elif ! docker info >/dev/null 2>&1; then
+  echo "WARN: docker daemon not running (skipped image check)"
+else
+  # local first
+  if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    note "   present locally"
+  else
+    note "   not local; checking registry…"
+    if docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
+      note "   available on registry (will pull on demand)"
+    else
+      fail "image $IMAGE not found locally or on registry"
+    fi
+  fi
+fi
+echo
+
+note "OK — checks complete (WARN lines are informational; FAIL is fatal)."

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -103,8 +103,10 @@ kleio_server_mode = KleioServerTestMode.DOCKER
 #     use when testing timelink-py against last public kleio-server images
 #
 use_kleio_image = "timelinkserver/kleio-server"
-# use latest or specific build e.g. 12.8.586
-use_kleio_version = "latest"
+# Pinned to a promoted build for reproducible test runs; keep in sync with
+# DEFAULT_KLEIO_VERSION in timelink/kleio/kleio_server.py and STACK.md.
+# Use "latest" only for ad-hoc checks against a newly released image.
+use_kleio_version = "12.9.588"
 
 skip_if_local = pytest.mark.skipif(
     kleio_server_mode == KleioServerTestMode.LOCAL, reason="Skipping test in LOCAL mode"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def kleio_server():
     # Image/version come from tests.__init__.py (single source of truth for
     # the test suite). To test a pre-release local kleio-server build, set
     # use_kleio_image = "kleio-server" and use_kleio_version = "12.9.591"
-    # there — or override via the $KLEIO_VERSION env var at runtime.
+    # there (or edit these variables locally for ad-hoc runs).
     kleio_image = test_settings.use_kleio_image
     kleio_version = test_settings.use_kleio_version
     kleio_external_port = 8089

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,11 +47,12 @@ def kleio_server():
     # The fixture behavior is controlled by values defined in tests.__init__.py.
     local = _use_local_kleio_server()
 
-    kleio_image = "timelinkserver/kleio-server"
-    kleio_version = "latest"
-    # For testing a pre release local version of Kleio server
-    # kleio_version = "12.9.591"
-    # kleio_image = "kleio-server"
+    # Image/version come from tests.__init__.py (single source of truth for
+    # the test suite). To test a pre-release local kleio-server build, set
+    # use_kleio_image = "kleio-server" and use_kleio_version = "12.9.591"
+    # there — or override via the $KLEIO_VERSION env var at runtime.
+    kleio_image = test_settings.use_kleio_image
+    kleio_version = test_settings.use_kleio_version
     kleio_external_port = 8089
     timeout_secs = 300
 

--- a/timelink/api/database.py
+++ b/timelink/api/database.py
@@ -431,23 +431,23 @@ class TimelinkDatabase(
         else:
             logging.info("Database is healthy")
 
-        # check if database is postgres and has the link_status type defined
+        # check if database is postgres and has the linkstatus type defined
         if self.db_type == "postgres":
             with self.engine.connect() as connection:
                 result = connection.execute(
                     select(text("1")).where(
                         text(
-                            "EXISTS (SELECT 1 FROM pg_type WHERE typname = 'link_status')"
+                            "EXISTS (SELECT 1 FROM pg_type WHERE typname = 'linkstatus')"
                         )
                     )
                 )
                 if result.scalar() is not None:
-                    logging.warning("link_status found, deleting it")
+                    logging.warning("linkstatus found, deleting it")
                     result = connection.execute(
-                        text("DROP TYPE IF EXISTS link_status CASCADE")
+                        text("DROP TYPE IF EXISTS linkstatus CASCADE")
                     )
                     # result = connection.execute(
-                    #     text("CREATE TYPE link_status AS ENUM ('valid', 'invalid', 'possible')")
+                    #     text("CREATE TYPE linkstatus AS ENUM ('valid', 'invalid', 'possible')")
                     # )
 
     def _build_dependency_graph(self, tables):

--- a/timelink/api/database.py
+++ b/timelink/api/database.py
@@ -260,7 +260,10 @@ class TimelinkDatabase(
                 raise Exception("Error while creating database") from exc
         else:
             try:
-
+                # Do not carry PomSomMapper cache entries over from
+                # previously connected databases; they would be merged
+                # into this one by _ensure_all_mappings below.
+                PomSomMapper.reset_cache()
                 self.check_db()  # health check to the database
                 migrations.upgrade(self.db_url)
                 with self.session() as session:
@@ -341,26 +344,89 @@ class TimelinkDatabase(
         """Check the database health and integrity.
 
         This method verifies that:
-        1. All required ORM tables exist in the database.
+        1. All tables expected in this database exist: the static timelink
+           tables plus the dynamic tables recorded in this database's own
+           "classes" table.
         2. Missing tables are created if needed.
         3. For PostgreSQL, checks for and removes obsolete 'linkstatus' type.
 
-        If missing tables are detected, they are created automatically.
+        The set of expected tables is derived from the database itself, not
+        from the global ORM registry. The SQLAlchemy metadata and the ORM
+        class registry are shared between databases opened in the same
+        process; walking them would report (and create) tables that only
+        belong to previously connected databases.
         """
-        db_tables = self.db_table_names()
-        orm_tables = Entity.get_orm_table_names()
-        missing = set(orm_tables) - set(db_tables)
+        db_tables = set(self.db_table_names())
+
+        # Static tables are the tables in the shared ORM metadata that were
+        # not created dynamically. Dynamic tables are flagged in their
+        # "info" dict (see PomSomMapper.ensure_mapping).
+        static_tables = {
+            table.name for table in self.metadata.tables.values() if not table.info.get("dynamic", False)
+        }
+
+        # Dynamic tables that belong to this database, according to its
+        # own "classes" table.
+        dynamic_tables = set()
+        if "classes" in db_tables:
+            try:
+                with self.session() as session:
+                    stmt = select(PomSomMapper.table_name).where(PomSomMapper.table_name.isnot(None))
+                    dynamic_tables = set(session.execute(stmt).scalars().all()) - static_tables
+            except Exception as exc:  # pylint: disable=broad-except
+                logging.warning(f"Could not read the classes table: {exc}")
+
+        expected = static_tables | dynamic_tables
+        missing = expected - db_tables
         if len(missing) > 0:
             logging.warning(f"Missing tables in database: {missing}")
             logging.warning("Creating tables")
-            # we need to create the tables
-            # remove dynamic tables from metadata
-            for dtable in self.db_dynamic_tables():
-                self.metadata.remove(dtable)
+            # Tables with a static definition are created from the metadata,
+            # but only those actually missing: the metadata is shared with
+            # other databases and may contain tables that do not belong here.
+            static_missing = [
+                table
+                for table in self.metadata.tables.values()
+                if table.name in missing and not table.info.get("dynamic", False)
+            ]
+            # Dynamically created tables are rebuilt from the class
+            # definitions stored in this database ("classes" and
+            # "class_attributes" tables).
+            dynamic_missing = sorted(missing - {table.name for table in static_missing})
             try:
-                self.metadata.create_all(self.engine)  # create the tables
+                if static_missing:
+                    self.metadata.create_all(self.engine, tables=static_missing)
+                if dynamic_missing:
+                    with self.session() as session:
+                        stmt = select(PomSomMapper).where(PomSomMapper.table_name.in_(dynamic_missing))
+                        pom_classes = session.execute(stmt).scalars().all()
+                        recreated = set()
+                        for pom_class in pom_classes:
+                            table_obj = self.metadata.tables.get(pom_class.table_name)
+                            orm_class = Entity.get_orm_for_pom_class(pom_class.id)
+                            if (
+                                table_obj is not None
+                                and orm_class is not None
+                                and orm_class.__mapper__.local_table is table_obj
+                            ):
+                                # A valid ORM mapping for this class survives
+                                # from earlier in this process; just recreate
+                                # the physical table.
+                                table_obj.create(self.engine)
+                            else:
+                                # Drop any stale Table object with this name:
+                                # it may belong to another database. The table
+                                # and ORM mapping are rebuilt from the class
+                                # definition stored in this database.
+                                if table_obj is not None:
+                                    self.metadata.remove(table_obj)
+                                pom_class.ensure_mapping(session)
+                            recreated.add(pom_class.table_name)
+                        lost = set(dynamic_missing) - recreated
+                        if lost:
+                            logging.error(f"Could not recreate tables, no class definition in this database: {lost}")
                 migrations.stamp(self.db_url, "head")
-            except Exception as exc:
+            except Exception as exc:  # pylint: disable=broad-except
                 logging.error(f"Error creating tables: {exc}")
         else:
             logging.info("Database is healthy")

--- a/timelink/api/database.py
+++ b/timelink/api/database.py
@@ -437,7 +437,7 @@ class TimelinkDatabase(
                 result = connection.execute(
                     select(text("1")).where(
                         text(
-                            "EXISTS (SELECT 1 FROM pg_type WHERE typname = 'linkstatus')"
+                            "EXISTS (SELECT 1 FROM pg_type WHERE typname = 'link_status')"
                         )
                     )
                 )

--- a/timelink/api/models/pom_som_mapper.py
+++ b/timelink/api/models/pom_som_mapper.py
@@ -282,6 +282,14 @@ class PomSomMapper(Entity):
 
         """
 
+        if self.id is None or self.table_name is None:
+            raise ValueError(
+                "Cannot ensure mapping for PomSomMapper with "
+                f"id={self.id!r} table_name={self.table_name!r}. "
+                "This usually indicates a stale mapper object cached from "
+                "a previously connected database."
+            )
+
         if not hasattr(self, "orm_class"):
             self.orm_class = None
 
@@ -344,7 +352,13 @@ class PomSomMapper(Entity):
             my_table = orm_tables[self.table_name]
         elif self.table_name in dbtables:
             # the table exists in the database, we introspect
-            my_table = Table(self.table_name, metadata_obj, autoload_with=dbengine)
+            # flag it as dynamic so it is not shared with other databases
+            my_table = Table(
+                self.table_name,
+                metadata_obj,
+                info={"dynamic": True, "pom_class_id": self.id},
+                autoload_with=dbengine,
+            )
             # we need to ensure that the foreign key relation exists with super talbe
             # otherwise the ORM mapping further down will fail.
             if self.super_class not in ["root", "base"]:
@@ -466,7 +480,8 @@ class PomSomMapper(Entity):
                 my_orm = type(self.id.capitalize(), (super_orm,), props)
                 my_orm.set_as_dynamic()  # mark as dynamic ORM
         except Exception as e:  # pylint: disable=broad-except
-            logger.ERROR(Exception(f"Could not create ORM mapping for {self.id}"), e)
+            logger.error("Could not create ORM mapping for %s: %s", self.id, e)
+            raise
 
         self.orm_class = my_orm
         PomSomMapper.group_orm_models[self.group_name] = my_orm
@@ -491,11 +506,14 @@ class PomSomMapper(Entity):
 
         stmt = select(cls)
         pom_classes = session.execute(stmt).scalars().all()
-        pom_class: PomSomMapper
-        for pom_class in pom_classes:
-            cls.pom_classes[pom_class.id] = pom_class
+        # Rebuild the cache from the current database only. Accumulating
+        # into the class-level dict leaks mapper objects (possibly expired
+        # or detached) from previously connected databases into this one;
+        # such stale entries later reach ensure_mapping() with None
+        # attributes and abort table creation.
+        cls.pom_classes = {pom_class.id: pom_class for pom_class in pom_classes}
 
-        return cls.pom_classes.values()
+        return list(cls.pom_classes.values())
 
     @classmethod
     def get_pom_class_ids(cls, session):

--- a/timelink/kleio/kleio_server.py
+++ b/timelink/kleio/kleio_server.py
@@ -16,6 +16,23 @@ from jsonrpcclient import Error, Ok, parse, request
 
 from .schemas import KleioFile, TokenInfo
 
+# Kleio server image tag used when no explicit version is requested.
+#
+# Pinned to a known-good promoted build rather than "latest" so that a new
+# kleio-server release cannot silently break timelink-py. Override per
+# environment with the $KLEIO_VERSION env var, or per call by passing
+# ``kleio_version=...`` to ``KleioServer.start``.
+#
+# See STACK.md at the repo root for the current verified-good combination of
+# kleio-server / timelink-py / timelink-docs. Update this constant as part of
+# a coordinated release (see RELEASE_CHECKLIST.md).
+DEFAULT_KLEIO_VERSION = "12.9.588"
+
+
+def get_default_kleio_version() -> str:
+    """Resolve the Kleio image tag: ``$KLEIO_VERSION`` env, else ``DEFAULT_KLEIO_VERSION``."""
+    return os.environ.get("KLEIO_VERSION") or DEFAULT_KLEIO_VERSION
+
 
 class KleioServerException(Exception):
     pass
@@ -88,7 +105,7 @@ class KleioServer:
     @staticmethod
     def start(
         kleio_image: str = "timelinkserver/kleio-server",
-        kleio_version: str | None = "latest",
+        kleio_version: str | None = None,
         kleio_home: str | None = None,
         kleio_admin_token: str | None = None,
         kleio_server_port=8088,
@@ -111,7 +128,10 @@ class KleioServer:
 
         Args:
             kleio_image (str): kleio server image, defaults to "timelinkserver/kleio-server"
-            kleio_version (str, optional): kleio-server image version, defaults to "latest"
+            kleio_version (str, optional): kleio-server image tag. ``None`` resolves to
+                ``$KLEIO_VERSION`` env var, else :data:`DEFAULT_KLEIO_VERSION`
+                (a pinned build, not "latest"). Pass an explicit tag (e.g.
+                ``"12.9.588"`` or ``"latest"``) to override.
             kleio_home (str, optional): kleio home directory,
                                         defaults to None -> current directory
             kleio_token (str, optional): kleio server admin token,
@@ -148,7 +168,7 @@ class KleioServer:
         if kleio_image is None:
             kleio_image = "timelinkserver/kleio-server"
         if kleio_version is None:
-            kleio_version = "latest"
+            kleio_version = get_default_kleio_version()
         if not is_docker_running():
             raise RuntimeError("Docker is not running")
         # TODO: test if kleio_home is a valid directory


### PR DESCRIPTION
## Summary

Fixes the postgres-only failure of `test_041_networks` (`Table(None)` / "Error creating table None for class None", missing tables `{'adendas','acusacoes','cartas','casos'}`) — see #94 for the full diagnosis.

This branch also includes the already-pushed stack-coordination framework commit (`44fef1d`: pin kleio version, STACK.md manifest, checklist); the fix itself is `815cffb`.

## The problem

In a process that connects to multiple timelink databases (e.g. a full local test-suite run), process-global SQLAlchemy state leaked across connections:

- `PomSomMapper.pom_classes`, a class-level cache, accumulated mapper objects across databases. `_ensure_all_mappings()` then `session.merge()`d expired/detached stale entries into the new database, producing mappers with `id=None, table_name=None` that crashed `ensure_mapping()` at `Table(None, ...)`.
- `check_db()` computed expected tables by walking the global ORM class registry (which cannot be un-mapped), so dynamic tables belonging to previously connected databases were reported missing and created in databases that never had them.

## The fix (`815cffb`)

- `PomSomMapper.get_pom_classes()` rebuilds the cache from the current database's rows only.
- `PomSomMapper.reset_cache()` when attaching to an existing database.
- `check_db()` derives expected tables from the database itself — static metadata tables plus the table names in its own `classes` table — and rebuilds missing dynamic tables from the database's own class definitions.
- Tables autoloaded into the shared metadata in `ensure_mapping()` are flagged `dynamic`.
- Clear `ValueError` for mappers with `None` `id`/`table_name` instead of the opaque SQLAlchemy assert.
- Fix `logger.ERROR` typo that masked the original ORM mapping error.

## Verification

- Full test suite green (274 passed, 13 skipped) on sqlite and postgres, including combined runs that previously triggered the failure.
- A deliberately dropped dynamic table is correctly rebuilt from the database's own class definitions on reopen (in-process and fresh-process).

Closes #94
