### PR TITLE
Wait for terminal translation status in update_from_sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,18 @@ timelink db upgrade <url> # Run migrations
 timelink mhk version      # Show MHK info
 ```
 
+## Commit Attribution
+
+Commits made by AI agents must be distinguishable from human commits.
+
+- Any AI coding agent committing to this repository must append a
+  `Co-authored-by` trailer identifying itself to every commit message it creates.
+- Kimi Work sessions use: `Co-authored-by: Kimi Agent <kimi-agent@localhost>`
+- Other agents use their own name and email in the same trailer format.
+- Do not change `user.name` / `user.email`; commit authorship stays with the
+  repository owner — agent attribution is via the trailer only.
+- Find agent commits with: `git log --grep="Co-authored-by"`
+
 ## Code Style Guidelines
 
 ### Formatting

--- a/tests/test_016_wait_for_translations.py
+++ b/tests/test_016_wait_for_translations.py
@@ -1,0 +1,122 @@
+"""Tests for TimelinkDatabase._wait_for_translations.
+
+Exercises the retry / terminal-error / timeout behavior with a fake kleio
+server that walks scripted status sequences — no real Kleio server needed.
+time.sleep is patched out so polls run back-to-back.
+
+Observed failure mode these tests lock in (kleio-server 12.9.588): a failed
+translation reverts the file to status "T" instead of a terminal state
+(trace: T -> P -> T -> P -> E), which the old P/Q-only wait loop turned
+into a silent skip. See issue #96.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from timelink.api.database import TimelinkDatabase
+
+
+class FakeKleioFile:
+    def __init__(self, path, status):
+        self.path = path
+        self.status = SimpleNamespace(value=status)
+
+
+class ScriptedKleioServer:
+    """Fake kleio server returning scripted translation statuses.
+
+    script: {path: [status, ...]} — each get_translations() call returns the
+    head of the list and advances it; the last status sticks once reached.
+    retry_script: {path: [status, ...]} — installed when translate() is
+    called for that path, modelling the server's behavior on a retry.
+    """
+
+    def __init__(self, script, retry_script=None):
+        self._seq = {p: list(seq) for p, seq in script.items()}
+        self._retry_script = retry_script or {}
+        self.translate_calls = []
+
+    def get_translations(self, path="", recurse=True, status=None):
+        files = []
+        for p, seq in self._seq.items():
+            files.append(FakeKleioFile(p, seq[0]))
+            if len(seq) > 1:
+                seq.pop(0)
+        return files
+
+    def translate(self, path, recurse="no", spawn="no"):
+        self.translate_calls.append(path)
+        if path in self._retry_script:
+            self._seq[path] = list(self._retry_script[path])
+
+
+@pytest.fixture
+def db(tmp_path):
+    return TimelinkDatabase(db_url=f"sqlite:///{tmp_path}/wait_test.db")
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    monkeypatch.setattr("timelink.api.database_kleio.time.sleep", lambda *_: None)
+
+
+def warnings_and_errors(caplog):
+    return [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_all_reach_terminal_status(db, caplog):
+    """Files that translate cleanly just finish; no retry, no warnings."""
+    db.kserver = ScriptedKleioServer({"a.cli": ["T", "P", "V"], "b.cli": ["Q", "P", "W"]})
+    db._wait_for_translations(["a.cli", "b.cli"])
+    assert db.kserver.translate_calls == []
+    assert warnings_and_errors(caplog) == []
+
+
+def test_failed_translation_is_retried_once(db, caplog):
+    """A revert from P back to T means the translation failed: retry once,
+    then accept the terminal status (here E, as the server does on retry)."""
+    db.kserver = ScriptedKleioServer(
+        {"good.cli": ["P", "V"], "bad.cli": ["T", "P", "T"]},
+        retry_script={"bad.cli": ["P", "E"]},
+    )
+    db._wait_for_translations(["good.cli", "bad.cli"])
+    assert db.kserver.translate_calls == ["bad.cli"]
+    messages = [r.getMessage() for r in warnings_and_errors(caplog)]
+    assert any("bad.cli failed; retrying" in m for m in messages)
+    assert any("bad.cli finished with errors" in m for m in messages)
+
+
+def test_second_failure_gives_up_with_error(db, caplog):
+    """A file that reverts to T again after the retry is reported and
+    dropped from the pending set — not silently skipped, not retried twice."""
+    db.kserver = ScriptedKleioServer(
+        {"bad.cli": ["P", "T"]},
+        retry_script={"bad.cli": ["P", "T"]},
+    )
+    db._wait_for_translations(["bad.cli"])
+    assert db.kserver.translate_calls == ["bad.cli"]
+    messages = [r.getMessage() for r in warnings_and_errors(caplog)]
+    assert any("bad.cli failed; retrying" in m for m in messages)
+    assert any("bad.cli failed twice" in m for m in messages)
+
+
+def test_translation_errors_accepted_when_requested(db, caplog):
+    """With with_translation_errors=True an E status is terminal but not an
+    error (the caller will import the file anyway)."""
+    db.kserver = ScriptedKleioServer({"e.cli": ["P", "E"]})
+    db._wait_for_translations(["e.cli"], with_translation_errors=True)
+    assert db.kserver.translate_calls == []
+    assert warnings_and_errors(caplog) == []
+
+
+def test_timeout_reports_unfinished_files(db, caplog):
+    """Files that never reach a terminal status (stuck in T, or absent from
+    the listing because the job was never registered) are reported."""
+    db.kserver = ScriptedKleioServer({"stuck.cli": ["T"]})
+    db._wait_for_translations(["stuck.cli", "ghost.cli"], max_wait=0)
+    assert db.kserver.translate_calls == []
+    messages = [r.getMessage() for r in warnings_and_errors(caplog)]
+    assert any("stuck.cli did not complete" in m for m in messages)
+    assert any("ghost.cli did not complete" in m for m in messages)

--- a/timelink/api/database_kleio.py
+++ b/timelink/api/database_kleio.py
@@ -218,20 +218,17 @@ class DatabaseKleioMixin:
             else:
                 translate_status = "T"  # only those that need translation
 
+            translate_requested = []
             for kfile in self.kserver.get_translations(path=path, recurse=recurse, status=translate_status):
                 logging.info("Request translation of %s %s", kfile.status.value, kfile.path)
                 self.kserver.translate(kfile.path, recurse="no", spawn="no")
+                translate_requested.append(kfile.path)
             # wait for translation to finish
-            logging.debug("Waiting for translations to finish")
-            pfiles = self.kserver.get_translations(path=path, recurse="yes", status="P")
-
-            qfiles = self.kserver.get_translations(path=path, recurse="yes", status="Q")
-            # TODO: change to import as each translation finishes
-            while len(pfiles) > 0 or len(qfiles) > 0:
-                time.sleep(1)
-
-                pfiles = self.kserver.get_translations(path="", recurse="yes", status="P")
-                qfiles = self.kserver.get_translations(path="", recurse="yes", status="Q")
+            if translate_requested:
+                self._wait_for_translations(
+                    translate_requested,
+                    with_translation_errors=with_translation_errors,
+                )
             # import the files
             to_import = self.kserver.get_translations(path=path, recurse=recurse, status="V")  # TODO recurse make param
             if with_translation_warnings:
@@ -271,6 +268,64 @@ class DatabaseKleioMixin:
                         logging.error("Unexpected error:")
                         logging.error("Error: %s", e)
                         continue
+
+    def _wait_for_translations(self, paths, with_translation_errors=False, max_wait=600):
+        """Wait until every file requested for translation reaches a terminal status.
+
+        A failed translation reverts the file to status "T" instead of a terminal
+        state, so watching only P/Q is not enough: a failed file disappears from
+        that watch and would be silently skipped at import time. Files observed to
+        revert from P/Q back to T are retried once; files that fail again, end with
+        translation errors, or do not finish before max_wait are logged as errors.
+
+        Args:
+            paths (list): Kleio server paths of the files requested for translation.
+            with_translation_errors (bool, optional): If True, files that finish with
+                translation errors are not reported as errors (they will be imported
+                anyway by the caller). Defaults to False.
+            max_wait (int, optional): Maximum seconds to wait for all translations
+                to reach a terminal status. Defaults to 600.
+        """
+        terminal = {"V", "W", "E"}
+        pending = set(paths)
+        active = set()  # files ever seen in P or Q since last (re)request
+        retried = set()
+        deadline = time.time() + max_wait
+        logging.debug("Waiting for translations to finish")
+        while pending and time.time() < deadline:
+            for rpath in list(pending):
+                kfiles = self.kserver.get_translations(path=rpath, recurse="no")
+                status = kfiles[0].status.value if len(kfiles) > 0 else None
+                if status in {"P", "Q"}:
+                    active.add(rpath)
+                elif status in terminal:
+                    pending.discard(rpath)
+                    if status == "E" and not with_translation_errors:
+                        logging.error(
+                            "Translation of %s finished with errors; file will not be imported",
+                            rpath,
+                        )
+                elif status == "T" and rpath in active:
+                    if rpath not in retried:
+                        retried.add(rpath)
+                        active.discard(rpath)
+                        logging.warning("Translation of %s failed; retrying", rpath)
+                        self.kserver.translate(rpath, recurse="no", spawn="no")
+                    else:
+                        pending.discard(rpath)
+                        logging.error(
+                            "Translation of %s failed twice; file will not be imported",
+                            rpath,
+                        )
+                # "T" and never active: job not yet registered on the server; keep waiting
+            if pending:
+                time.sleep(1)
+        for rpath in sorted(pending):
+            logging.error(
+                "Translation of %s did not complete within %ss; file will not be imported",
+                rpath,
+                max_wait,
+            )
 
     def import_from_xml(self, file: str | KleioFile, kserver=None, return_stats=True):
         """Import one file

--- a/timelink/api/database_kleio.py
+++ b/timelink/api/database_kleio.py
@@ -227,6 +227,8 @@ class DatabaseKleioMixin:
             if translate_requested:
                 self._wait_for_translations(
                     translate_requested,
+                    source_path=path,
+                    source_recurse=recurse,
                     with_translation_errors=with_translation_errors,
                 )
             # import the files
@@ -269,7 +271,14 @@ class DatabaseKleioMixin:
                         logging.error("Error: %s", e)
                         continue
 
-    def _wait_for_translations(self, paths, with_translation_errors=False, max_wait=600):
+    def _wait_for_translations(
+        self,
+        paths,
+        source_path="",
+        source_recurse=True,
+        with_translation_errors=False,
+        max_wait=600,
+    ):
         """Wait until every file requested for translation reaches a terminal status.
 
         A failed translation reverts the file to status "T" instead of a terminal
@@ -278,8 +287,16 @@ class DatabaseKleioMixin:
         revert from P/Q back to T are retried once; files that fail again, end with
         translation errors, or do not finish before max_wait are logged as errors.
 
+        Statuses are polled with a single server call per iteration (scoped to
+        ``source_path``), so polling cost stays constant no matter how many
+        files are being translated.
+
         Args:
             paths (list): Kleio server paths of the files requested for translation.
+            source_path (str, optional): Base path for the status listing; must
+                cover all ``paths``. Defaults to "" (whole server).
+            source_recurse (bool, optional): Recurse ``source_path`` in the status
+                listing. Defaults to True.
             with_translation_errors (bool, optional): If True, files that finish with
                 translation errors are not reported as errors (they will be imported
                 anyway by the caller). Defaults to False.
@@ -293,9 +310,10 @@ class DatabaseKleioMixin:
         deadline = time.time() + max_wait
         logging.debug("Waiting for translations to finish")
         while pending and time.time() < deadline:
+            listing = self.kserver.get_translations(path=source_path, recurse=source_recurse)
+            statuses = {kfile.path: kfile.status.value for kfile in listing}
             for rpath in list(pending):
-                kfiles = self.kserver.get_translations(path=rpath, recurse="no")
-                status = kfiles[0].status.value if len(kfiles) > 0 else None
+                status = statuses.get(rpath)
                 if status in {"P", "Q"}:
                     active.add(rpath)
                 elif status in terminal:
@@ -317,7 +335,8 @@ class DatabaseKleioMixin:
                             "Translation of %s failed twice; file will not be imported",
                             rpath,
                         )
-                # "T" and never active: job not yet registered on the server; keep waiting
+                # "T" or absent from the listing, and never active: job not yet
+                # registered on the server; keep waiting
             if pending:
                 time.sleep(1)
         for rpath in sorted(pending):


### PR DESCRIPTION
Closes #96.

## Problem

`update_from_sources` requested translations fire-and-forget and then only watched statuses `P`/`Q`. A failed translation reverts the file to `T` instead of a terminal status, so it disappeared from the watch and was silently skipped at import time — the cause of the flaky `tests/test_040_pandas.py::test_name_to_df[dbsystem0]` CI failure on #95's 3.13 job.

## Change

- `update_from_sources` collects the paths it requested and delegates the wait to a new `_wait_for_translations` helper.
- The helper polls each requested file until it reaches a terminal status (`V`, `W`, `E`):
  - a file seen to revert from `P`/`Q` back to `T` is retried once (WARNING logged);
  - a file that fails again, ends in `E`, or exceeds the 600 s deadline is reported with an ERROR log instead of being silently skipped.
- The wait is now scoped to the requested paths rather than any `P`/`Q` file on the server.

## Verification

- Scratch kleio home with one good file (`b1685.cli`) and one file that always fails translation: status trace `T -> P -> T -> P -> E`; WARNING `failed; retrying` and ERROR `finished with errors; file will not be imported` logged; good file imported (757 entities); no hang.
- Regression: `tests/test_040_pandas.py` + `tests/test_041_networks.py` (14 passed, sqlite + postgres) and `tests/test_050_import_TL.py -k dbsystem0` (10 passed).

## Base

Stacked on `feature/stack-coordination` (#95) so the diff shows only this change; GitHub will retarget to `main` automatically when #95 merges and its branch is deleted (or retarget manually).

Note: this branch also contains `0f30afa` (docs: AGENTS.md commit-attribution rule), which was committed onto this branch before the fix commit; it is unrelated to the fix but harmless to merge along.
