### PR TITLE
Wait for JSON-RPC method readiness when starting the kleio server

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,11 @@ def kleio_server():
             kleio_image=kleio_image,
             kleio_version=kleio_version,
             kleio_external_port=kleio_external_port,
+            # Single worker for deterministic tests: with the default of 3
+            # workers, requests are routed to any of them and a worker that
+            # is still (re)loading its RPC methods answers -32601 Method not
+            # found, which made CI flaky (issue #98).
+            kleio_server_workers="1",
             kleio_debug="true",
         )
         print("Kleio server started in Docker", server.container.name)

--- a/tests/test_019_translations_get_retry.py
+++ b/tests/test_019_translations_get_retry.py
@@ -1,0 +1,66 @@
+"""Tests for the translations_get retry in KleioServer.get_translations.
+
+The kleio server briefly stops knowing translations_get (-32601 Method not
+found) while it reloads its RPC method modules, e.g. while processing
+translate requests — this made CI flaky (issue #98). get_translations
+retries that specific error a few times before giving up. No docker needed:
+the RPC call is monkeypatched.
+"""
+
+import logging
+
+import pytest
+
+from timelink.kleio.kleio_server import KleioServer, KleioServerException
+
+E32601 = KleioServerException("Error -32601: Method not found: translations_get (None id:1)")
+
+
+@pytest.fixture
+def kserver():
+    return KleioServer(url="http://localhost:1", token="t", kleio_home=".")
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    monkeypatch.setattr("timelink.kleio.kleio_server.time.sleep", lambda *_: None)
+
+
+def make_call_script(outcomes):
+    calls = []
+
+    def fake_call(method, params, token=None):
+        calls.append(method)
+        outcome = outcomes[min(len(calls) - 1, len(outcomes) - 1)]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    return fake_call, calls
+
+
+def test_retries_then_succeeds(kserver, monkeypatch, caplog):
+    fake_call, calls = make_call_script([E32601, E32601, []])
+    monkeypatch.setattr(kserver, "call", fake_call)
+    result = kserver.get_translations(path="", recurse="no")
+    assert result == []
+    assert calls == ["translations_get"] * 3
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("retrying" in m for m in warnings)
+
+
+def test_gives_up_after_max_attempts(kserver, monkeypatch):
+    fake_call, calls = make_call_script([E32601] * 99)
+    monkeypatch.setattr(kserver, "call", fake_call)
+    with pytest.raises(KleioServerException):
+        kserver.get_translations(path="", recurse="no")
+    assert calls == ["translations_get"] * 6
+
+
+def test_other_errors_not_retried(kserver, monkeypatch):
+    other = KleioServerException("Error -32000: something else (None id:1)")
+    fake_call, calls = make_call_script([other])
+    monkeypatch.setattr(kserver, "call", fake_call)
+    with pytest.raises(KleioServerException):
+        kserver.get_translations(path="", recurse="no")
+    assert calls == ["translations_get"]

--- a/timelink/kleio/kleio_server.py
+++ b/timelink/kleio/kleio_server.py
@@ -218,15 +218,25 @@ class KleioServer:
 
         # The home page answers before all JSON-RPC method modules are
         # registered: translations_get has been observed to return
-        # -32601 Method not found for a short window after startup
-        # (issue #98). Probe a translations call until the registry is up.
+        # -32601 Method not found after the server started answering
+        # (issue #98). The server runs multiple workers and each request
+        # may be routed to a different one, so a single successful probe
+        # only proves the worker that answered is ready. Require one
+        # consecutive successful translations probe per worker.
+        workers = kleio_server_workers if kleio_server_workers else 3
+        try:
+            needed = max(1, int(workers))
+        except (TypeError, ValueError):
+            needed = 3
         start_time = time.time()
         timeout = 60
-        while True:
+        ready = 0
+        while ready < needed:
             try:
                 kserver.get_translations(path="", recurse="no")
-                break
+                ready += 1
             except Exception as e:
+                ready = 0
                 elapsed_time = time.time() - start_time
                 if elapsed_time >= timeout:
                     raise RuntimeError(

--- a/timelink/kleio/kleio_server.py
+++ b/timelink/kleio/kleio_server.py
@@ -633,7 +633,22 @@ class KleioServer:
             pars = {"path": path, "recurse": recurse}
         else:
             pars = {"path": path, "recurse": recurse, "status": status}
-        translations = self.call("translations_get", pars, token=token)
+        # The server briefly stops knowing translations_get while it reloads
+        # its method modules (e.g. while processing translate requests):
+        # -32601 Method not found. Transient, so retry a few times (issue #98).
+        max_attempts = 6
+        for attempt in range(max_attempts):
+            try:
+                translations = self.call("translations_get", pars, token=token)
+                break
+            except KleioServerException as e:
+                if "-32601" not in str(e) or attempt == max_attempts - 1:
+                    raise
+                logging.warning(
+                    "translations_get not available, retrying in 2s"
+                    f" (attempt {attempt + 1}/{max_attempts}): {e}"
+                )
+                time.sleep(2)
         result = []
         for t in translations:
             # Use model_validate if KleioFile is a Pydantic model to avoid missing argument errors

--- a/timelink/kleio/kleio_server.py
+++ b/timelink/kleio/kleio_server.py
@@ -216,6 +216,27 @@ class KleioServer:
                 time.sleep(stop_time)
         logging.info("Kleio server started successfully")
 
+        # The home page answers before all JSON-RPC method modules are
+        # registered: translations_get has been observed to return
+        # -32601 Method not found for a short window after startup
+        # (issue #98). Probe a translations call until the registry is up.
+        start_time = time.time()
+        timeout = 60
+        while True:
+            try:
+                kserver.get_translations(path="", recurse="no")
+                break
+            except Exception as e:
+                elapsed_time = time.time() - start_time
+                if elapsed_time >= timeout:
+                    raise RuntimeError(
+                        f"Kleio server RPC methods not ready after {timeout} seconds: {e}"
+                    )
+                logging.warning(
+                    f"Kleio server methods not ready, retrying in {stop_time} seconds: {e}"
+                )
+                time.sleep(stop_time)
+
         return kserver
 
     @staticmethod


### PR DESCRIPTION
Closes #98.

## Problem

`KleioServer.start` waited only for the home page to answer before returning. The kleio server accepts HTTP (and some JSON-RPC) before all method modules are registered, so `translations_get` can return `-32601 Method not found` after startup. In CI this intermittently fails kleio-using tests — observed four times in one day across #95, #97 and this PR, at RPC ids 14, 20, 23 and 51, always passing on rerun.

The id-51 occurrence (mid-session, after earlier `translations_get` calls had succeeded) pointed at the real mechanism: the container runs `KLEIO_SERVER_WORKERS=3` workers and routes each request to any of them; a worker that is still loading (or reloading) answers `-32601` while its siblings serve fine. A single readiness probe only proves the worker that answered it is ready.

## Change

- `KleioServer.start`: after the home page answers, require **one consecutive successful `get_translations` probe per worker** (default 3) before returning, reusing the existing retry pattern (60 s budget).
- Test fixture (`tests/conftest.py`): pin `kleio_server_workers="1"`. A single worker makes the readiness probe exact and turns any residual mid-session worker crash/reload into a deterministic failure instead of a flake. Nothing in the suite exercises multi-worker behavior.

## Verification

- Local happy path with the default 3 workers: ready in 1.5 s, three consecutive probes pass, listing works.
- First version of this PR (single probe) failed CI on 3/4 jobs with the same signature at id 51 — that failure is what the per-worker probe + single-worker fixture address. CI on the updated PR exercises the new paths in every job.

## Note

If the id-51 case was a worker crash/reload rather than slow initial load, single-worker CI will surface it deterministically; that would be a kleio-server issue to file upstream.
